### PR TITLE
CP-15358: support external ip address setting

### DIFF
--- a/src/xn.ml
+++ b/src/xn.ml
@@ -289,6 +289,7 @@ let parse_vif vm_id (x, idx) =
 		rate = None;
 		backend = if List.mem_assoc _bridge kvpairs then Network.Local (List.assoc _bridge kvpairs) else Network.Local "xenbr0";
 		other_config = [];
+		static_ip_setting = [];
 		locking_mode = Vif.Unlocked;
 		extra_private_keys = [];
 	}


### PR DESCRIPTION
extend vif-param-set to set following xenstore keys, then windows guest agent reads these keys to write static ip setting to windows guest os

xenserver
device = ""
vif = ""
static-ip-setting = ""
mac = "ae:0e:ad:e7:a5:6e"
error-code = "0"
error-msg = ""
address6 = "2001:0DB8:02de:1000::0e13/64"
gateway6 = "2001:0DB8:02de:1000::1"
address = "10.158.180.45/24"
gateway = "10.158.180.1"
enabled = "0"

Test
1. job 1313442, ring3 bvt
2. job 1313440, ring3 bvt