### PR TITLE
Fix infinite loop on import

### DIFF
--- a/src/xn.ml
+++ b/src/xn.ml
@@ -620,8 +620,9 @@ let import_metadata copts filename =
 		(fun () ->
 			try
 				while true do
-					let n = input ic line 0 (String.length line) in
-					Buffer.add_string buf (String.sub line 0 n)
+					match input ic line 0 (String.length line) with
+					| 0 -> raise End_of_file
+					| n -> Buffer.add_string buf (String.sub line 0 n)
 				done
 				with End_of_file -> ()
 		) (fun () -> close_in ic);


### PR DESCRIPTION
Pervasives.import never throws End_of_file but instead returns 0 when
the end of file is reached.

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>